### PR TITLE
Refactor(#424): 레거지 paymentDto 네이밍 변경 및 일부 api DTO 선 적용

### DIFF
--- a/src/common/dtos/basic-lecture-with-image.dto.ts
+++ b/src/common/dtos/basic-lecture-with-image.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Lecture, LectureImage } from '@prisma/client';
+import { Exclude, Expose, Transform } from 'class-transformer';
+
+@Exclude()
+export class BasicLectureWithImageDto implements Pick<Lecture, 'id' | 'title'> {
+  @ApiProperty({
+    description: '강의 id',
+    type: Number,
+  })
+  @Expose()
+  id: number;
+
+  @ApiProperty({
+    description: '강의 제목',
+  })
+  @Expose()
+  title: string;
+
+  @ApiProperty({
+    description: '강의 이미지 url',
+  })
+  @Transform(({ obj }) => obj && obj.lectureImage[0]?.imageUrl, {
+    toPlainOnly: true,
+  })
+  @Expose()
+  imageUrl?: string;
+
+  lectureImage?: LectureImage[];
+}

--- a/src/common/dtos/basic-reservation.dto.ts
+++ b/src/common/dtos/basic-reservation.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type, Expose, Exclude } from 'class-transformer';
+import { Reservation } from '@prisma/client';
+import { RegularLectureStatusDto } from './regular-lecture-status.dto';
+import { LectureScheduleDto } from './lecture-schedule.dto';
+
+@Exclude()
+export class BasicReservationDto implements Reservation {
+  @ApiProperty({
+    description: '예약 Id',
+    type: Number,
+  })
+  @Expose()
+  id: number;
+
+  @ApiProperty({
+    description: '예약자명',
+  })
+  @Expose()
+  representative: string;
+
+  @ApiProperty({
+    description: '예약자 전화 번호',
+  })
+  @Expose()
+  phoneNumber: string;
+
+  @ApiProperty({
+    description: '예약 인원',
+  })
+  @Expose()
+  participants: number;
+
+  @ApiProperty({
+    description: '요청 상황',
+  })
+  @Expose()
+  requests: string;
+
+  @ApiProperty({
+    type: RegularLectureStatusDto,
+    description: '정기 클래스 일정',
+  })
+  @Type(() => RegularLectureStatusDto)
+  @Expose()
+  regularLectureStatus?: RegularLectureStatusDto;
+
+  @ApiProperty({
+    type: LectureScheduleDto,
+    description: '원데이 클래스 일정',
+  })
+  @Type(() => LectureScheduleDto)
+  @Expose()
+  lectureSchedule?: LectureScheduleDto;
+
+  isEnabled: boolean;
+
+  userId: number;
+  paymentId: number;
+  lectureScheduleId: number;
+  lectureId: number;
+  regularLectureStatusId: number;
+}

--- a/src/common/dtos/lecturer-learner.dto.ts
+++ b/src/common/dtos/lecturer-learner.dto.ts
@@ -1,7 +1,7 @@
 import { LecturerLearner } from '@prisma/client';
 import { BaseReturnDto } from './base-return.dto';
 import { UserDto } from './user.dto';
-import { ReservationDto } from './reservation.dto';
+import { LegacyReservationDto } from './legacy-reservation.dto';
 import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
 import { UserProfileImageDto } from './user-profile-image.dto';
@@ -71,10 +71,10 @@ export class LecturerLearnerDto
 
   @ApiProperty({
     description: '예약 정보',
-    type: ReservationDto,
+    type: LegacyReservationDto,
   })
   @Expose()
-  reservation?: ReservationDto;
+  reservation?: LegacyReservationDto;
 
   constructor(lecturerLearner: Partial<LecturerLearnerDto>) {
     super();
@@ -85,7 +85,7 @@ export class LecturerLearnerDto
       : undefined;
 
     this.reservation = lecturerLearner.reservation
-      ? new ReservationDto(lecturerLearner.reservation)
+      ? new LegacyReservationDto(lecturerLearner.reservation)
       : undefined;
   }
 }

--- a/src/common/dtos/legacy-reservation.dto.ts
+++ b/src/common/dtos/legacy-reservation.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Reservation } from '@prisma/client';
-import { PaymentLectureScheduleWithLectureDto } from '@src/payments/dtos/payment-lecture-schedule.dto';
+import { LegacyPaymentLectureScheduleWithLectureDto } from '@src/payments/dtos/legacy-payment-lecture-schedule.dto';
 import { PaymentRegularLectureStatusDto } from '@src/payments/dtos/payment-regular-lecture-status.dto';
-import { PaymentDto } from '@src/payments/dtos/payment.dto';
+import { LegacyPaymentDto } from '@src/payments/dtos/legacy-payment.dto';
 import { Exclude, Expose, Type } from 'class-transformer';
 
 @Exclude()
-export class ReservationDto implements Reservation {
+export class LegacyReservationDto implements Reservation {
   @ApiProperty({
     description: '예약 Id',
     type: Number,
@@ -48,11 +48,11 @@ export class ReservationDto implements Reservation {
 
   @ApiProperty({
     description: '원데이 클래스 일정',
-    type: PaymentLectureScheduleWithLectureDto,
+    type: LegacyPaymentLectureScheduleWithLectureDto,
   })
-  @Type(() => PaymentLectureScheduleWithLectureDto)
+  @Type(() => LegacyPaymentLectureScheduleWithLectureDto)
   @Expose()
-  lectureSchedule?: PaymentLectureScheduleWithLectureDto;
+  lectureSchedule?: LegacyPaymentLectureScheduleWithLectureDto;
 
   @ApiProperty({
     description: '정기 클래스 일정',
@@ -62,9 +62,9 @@ export class ReservationDto implements Reservation {
   @Expose()
   regularLectureStatus?: PaymentRegularLectureStatusDto;
 
-  payment?: PaymentDto;
+  payment?: LegacyPaymentDto;
 
-  constructor(reservation: Partial<ReservationDto>) {
+  constructor(reservation: Partial<LegacyReservationDto>) {
     Object.assign(this, reservation);
   }
 }

--- a/src/common/dtos/reservation-with-lecture-image.dto.ts
+++ b/src/common/dtos/reservation-with-lecture-image.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose, Type } from 'class-transformer';
+import { BasicReservationDto } from './basic-reservation.dto';
+import { BasicLectureWithImageDto } from './basic-lecture-with-image.dto';
+
+@Exclude()
+export class ReservationWithLectureImageDto extends BasicReservationDto {
+  @ApiProperty({
+    type: BasicLectureWithImageDto,
+    description: '강의 정보',
+  })
+  @Type(() => BasicLectureWithImageDto)
+  @Expose()
+  lecture: BasicLectureWithImageDto;
+}

--- a/src/common/dtos/reservation-with-lecture.dto.ts
+++ b/src/common/dtos/reservation-with-lecture.dto.ts
@@ -1,45 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type, Expose, Exclude } from 'class-transformer';
-import { Reservation } from '@prisma/client';
 import { BasicLectureDto } from './basic-lecture.dto';
-import { RegularLectureStatusDto } from './regular-lecture-status.dto';
-import { LectureScheduleDto } from './lecture-schedule.dto';
+import { BasicReservationDto } from './basic-reservation.dto';
 
 @Exclude()
-export class ReservationWithLectureDto implements Reservation {
-  @ApiProperty({
-    description: '예약 Id',
-    type: Number,
-  })
-  @Expose()
-  id: number;
-
-  @ApiProperty({
-    description: '예약자명',
-  })
-  @Expose()
-  representative: string;
-
-  @ApiProperty({
-    description: '예약자 전화 번호',
-  })
-  @Expose()
-  phoneNumber: string;
-
-  @ApiProperty({
-    description: '예약 인원',
-  })
-  @Expose()
-  participants: number;
-
-  @ApiProperty({
-    description: '요청 상황',
-  })
-  @Expose()
-  requests: string;
-
-  isEnabled: boolean;
-
+export class ReservationWithLectureDto extends BasicReservationDto {
   @ApiProperty({
     type: BasicLectureDto,
     description: '강의 정보',
@@ -47,26 +12,4 @@ export class ReservationWithLectureDto implements Reservation {
   @Type(() => BasicLectureDto)
   @Expose()
   lecture: BasicLectureDto;
-
-  @ApiProperty({
-    type: RegularLectureStatusDto,
-    description: '정기 클래스 일정',
-  })
-  @Type(() => RegularLectureStatusDto)
-  @Expose()
-  regularLectureStatus?: RegularLectureStatusDto;
-
-  @ApiProperty({
-    type: LectureScheduleDto,
-    description: '원데이 클래스 일정',
-  })
-  @Type(() => LectureScheduleDto)
-  @Expose()
-  lectureSchedule?: LectureScheduleDto;
-
-  userId: number;
-  paymentId: number;
-  lectureScheduleId: number;
-  lectureId: number;
-  regularLectureStatusId: number;
 }

--- a/src/lecture/dtos/get-detail-enroll-schedule.dto.ts
+++ b/src/lecture/dtos/get-detail-enroll-schedule.dto.ts
@@ -4,7 +4,7 @@ import { LectureScheduleWithLectureDto } from '@src/common/dtos/lecture-schedule
 import { LecturerDto } from '@src/common/dtos/lecturer.dto';
 import { RegularLectureScheduleDto } from '@src/common/dtos/regular-lecture-schedule.dto';
 import { RegularLectureStatusWithLectureDto } from '@src/common/dtos/regular-lecture-status-with-lecture.dto';
-import { ReservationDto } from '@src/common/dtos/reservation.dto';
+import { LegacyReservationDto } from '@src/common/dtos/legacy-reservation.dto';
 import { Exclude, Expose, Type } from 'class-transformer';
 import { EnrollScheduleDetailPriceDto } from './enroll-schedule-detail-price.dto';
 
@@ -66,7 +66,7 @@ export class DetailEnrollScheduleDto {
 
   regularLectureStatus?: RegularLectureStatusWithLectureDto;
 
-  constructor(reservation: Partial<ReservationDto>) {
+  constructor(reservation: Partial<LegacyReservationDto>) {
     Object.assign(this, reservation);
 
     this.lecture = reservation.lectureSchedule

--- a/src/lecture/interface/lecture.interface.ts
+++ b/src/lecture/interface/lecture.interface.ts
@@ -13,7 +13,7 @@ import { LecturerDto } from '@src/common/dtos/lecturer.dto';
 import { LikedLectureReviewDto } from '@src/common/dtos/liked-lecture-review.dto';
 import { LikedLectureDto } from '@src/common/dtos/liked-lecture.dto';
 import { RegularLectureStatusWithLectureDto } from '@src/common/dtos/regular-lecture-status-with-lecture.dto';
-import { ReservationDto } from '@src/common/dtos/reservation.dto';
+import { LegacyReservationDto } from '@src/common/dtos/legacy-reservation.dto';
 import { UserDto } from '@src/common/dtos/user.dto';
 
 interface ILecture extends Omit<LectureDto, 'stars'> {
@@ -31,7 +31,7 @@ interface ILectureReview
   users: UserDto;
   lecture: Lecture;
   likedLectureReview?: LikedLectureReviewDto[];
-  reservation: ReservationDto;
+  reservation: LegacyReservationDto;
   _count: { [likedLectureReview: string]: number };
 }
 

--- a/src/lecturer/dtos/learner-payment-overview.dto.ts
+++ b/src/lecturer/dtos/learner-payment-overview.dto.ts
@@ -1,5 +1,5 @@
 import { LearnerPassDto } from './learner-pass.dto';
-import { ReservationDto } from '@src/common/dtos/reservation.dto';
+import { LegacyReservationDto } from '@src/common/dtos/legacy-reservation.dto';
 import { PaymentCouponUsageDto } from '@src/payments/dtos/payment-coupon-usage.dto';
 import { PaymentPassUsageDto } from '@src/payments/dtos/payment-pass-usage.dto';
 import { PaymentProductTypeDto } from '@src/payments/dtos/payment-product-type.dto';
@@ -54,11 +54,11 @@ export class LearnerPaymentOverviewDto
   paymentCouponUsage: PaymentCouponUsageDto;
 
   @ApiProperty({
-    type: ReservationDto,
+    type: LegacyReservationDto,
     description: '예약 정보',
     nullable: true,
   })
-  reservation: ReservationDto;
+  reservation: LegacyReservationDto;
 
   @ApiProperty({
     type: PaymentPassUsageDto,
@@ -88,7 +88,7 @@ export class LearnerPaymentOverviewDto
     );
 
     this.reservation = learnerOverview.reservation
-      ? new ReservationDto(learnerOverview.reservation)
+      ? new LegacyReservationDto(learnerOverview.reservation)
       : null;
     this.paymentCouponUsage = learnerOverview.paymentCouponUsage
       ? new PaymentCouponUsageDto(learnerOverview.paymentCouponUsage)

--- a/src/lecturer/dtos/response/lecturer-reservation.dto.ts
+++ b/src/lecturer/dtos/response/lecturer-reservation.dto.ts
@@ -1,13 +1,13 @@
-import { ReservationDto } from '@src/common/dtos/reservation.dto';
+import { LegacyReservationDto } from '@src/common/dtos/legacy-reservation.dto';
 import { SimpleLectureDto } from '../simple-lecture.dto';
 import { Exclude, Expose, Transform, Type } from 'class-transformer';
 import { ApiProperty, OmitType } from '@nestjs/swagger';
 import { UserWithProfileImageDto } from '@src/common/dtos/user-with-profile-image.dto';
-import { PaymentLectureScheduleWithLectureDto } from '@src/payments/dtos/payment-lecture-schedule.dto';
+import { LegacyPaymentLectureScheduleWithLectureDto } from '@src/payments/dtos/legacy-payment-lecture-schedule.dto';
 import { PaymentRegularLectureStatusDto } from '@src/payments/dtos/payment-regular-lecture-status.dto';
 @Exclude()
 class LecturerReservationOneDayScheduleDto extends OmitType(
-  PaymentLectureScheduleWithLectureDto,
+  LegacyPaymentLectureScheduleWithLectureDto,
   ['lecture'],
 ) {}
 @Exclude()
@@ -26,7 +26,7 @@ class LecturerReservationLectureDto extends SimpleLectureDto {
 }
 
 @Exclude()
-export class LecturerReservationDto extends ReservationDto {
+export class LecturerReservationDto extends LegacyReservationDto {
   @ApiProperty({
     type: LecturerReservationLectureDto,
     description: '강의 정보',

--- a/src/pass/dtos/response/pass-history.dto.ts
+++ b/src/pass/dtos/response/pass-history.dto.ts
@@ -1,11 +1,11 @@
 import { ApiProperty, OmitType, PickType } from '@nestjs/swagger';
 import { BasicLectureDto } from '@src/common/dtos/basic-lecture.dto';
-import { ReservationDto } from '@src/common/dtos/reservation.dto';
-import { PaymentLectureScheduleWithLectureDto } from '@src/payments/dtos/payment-lecture-schedule.dto';
-import { PaymentDto } from '@src/payments/dtos/payment.dto';
+import { LegacyReservationDto } from '@src/common/dtos/legacy-reservation.dto';
+import { LegacyPaymentLectureScheduleWithLectureDto } from '@src/payments/dtos/legacy-payment-lecture-schedule.dto';
+import { LegacyPaymentDto } from '@src/payments/dtos/legacy-payment.dto';
 import { Exclude, Expose, Type } from 'class-transformer';
 @Exclude()
-class PassReservationPaymentDto extends PickType(PaymentDto, [
+class PassReservationPaymentDto extends PickType(LegacyPaymentDto, [
   'id',
   'createdAt',
   'updatedAt',
@@ -13,7 +13,7 @@ class PassReservationPaymentDto extends PickType(PaymentDto, [
 
 @Exclude()
 class PassReservationLectureScheduleDto extends OmitType(
-  PaymentLectureScheduleWithLectureDto,
+  LegacyPaymentLectureScheduleWithLectureDto,
   ['lecture'],
 ) {
   @ApiProperty({
@@ -26,7 +26,7 @@ class PassReservationLectureScheduleDto extends OmitType(
 }
 
 @Exclude()
-export class PassReservationDto extends OmitType(ReservationDto, [
+export class PassReservationDto extends OmitType(LegacyReservationDto, [
   'regularLectureStatus',
   'lectureSchedule',
   'payment',

--- a/src/payments/controllers/swagger/payments.swagger.ts
+++ b/src/payments/controllers/swagger/payments.swagger.ts
@@ -8,7 +8,7 @@ import { DetailResponseDto } from '@src/common/swagger/dtos/detail-response-dto'
 import { PaymentsController } from '../payments.controller';
 import { LecturePaymentWithPassUsageDto } from '@src/payments/dtos/response/lecture-payment-with-pass-usage.dto';
 import { PendingPaymentInfoDto } from '@src/payments/dtos/pending-payment-info.dto';
-import { PaymentDto } from '@src/payments/dtos/payment.dto';
+import { LegacyPaymentDto } from '@src/payments/dtos/legacy-payment.dto';
 import { PaymentResultDto } from '@src/payments/dtos/response/payment-result.dto';
 
 export const ApiPayments: ApiOperator<keyof PaymentsController> = {

--- a/src/payments/controllers/user-payments.controller.ts
+++ b/src/payments/controllers/user-payments.controller.ts
@@ -23,7 +23,8 @@ import { ApiCreateUserBankAccount } from '../swagger-decorators/save-user-bank-a
 import { ApiGetUserRecentBankAccount } from '../swagger-decorators/get-user-recent-bank-account.decorator';
 import { UserPaymentsHistoryWithCountDto } from '../dtos/user-payment-history-list.dto';
 import { ApiGetUserReceipt } from '../swagger-decorators/get-user-receipt-decorator';
-import { PaymentDto } from '../dtos/payment.dto';
+import { LegacyPaymentDto } from '../dtos/legacy-payment.dto';
+import { DetailPaymentInfo } from '../dtos/response/detail-payment.dto';
 
 @ApiTags('유저-결제')
 @Controller('user-payments')
@@ -50,7 +51,7 @@ export class UserPaymentsController {
   async getUserReceipt(
     @GetAuthorizedUser() authorizedData: ValidateResult,
     @Param('orderId') orderId: string,
-  ): Promise<PaymentDto> {
+  ): Promise<DetailPaymentInfo> {
     return await this.userPaymentsService.getUserReceipt(
       authorizedData.user.id,
       orderId,

--- a/src/payments/dtos/lecturer-payment.dto.ts
+++ b/src/payments/dtos/lecturer-payment.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from '@src/common/dtos/user.dto';
-import { PaymentDto } from './payment.dto';
+import { LegacyPaymentDto } from './legacy-payment.dto';
 
 //신청한 유저의 프로필을 포함한 Dto
-export class LecturerPaymentDto extends PaymentDto {
+export class LecturerPaymentDto extends LegacyPaymentDto {
   @ApiProperty({
     type: UserDto,
     description: '신청한 유저 프로필카드',

--- a/src/payments/dtos/legacy-payment-lecture-schedule.dto.ts
+++ b/src/payments/dtos/legacy-payment-lecture-schedule.dto.ts
@@ -27,7 +27,7 @@ class PrivateSimpleLecture extends SimpleLectureDto {
 }
 
 @Exclude()
-export class PaymentLectureScheduleWithLectureDto extends BasicPaymentLectureScheduleDto {
+export class LegacyPaymentLectureScheduleWithLectureDto extends BasicPaymentLectureScheduleDto {
   @ApiProperty({
     description: '강의 정보',
     type: PrivateSimpleLecture,
@@ -36,7 +36,9 @@ export class PaymentLectureScheduleWithLectureDto extends BasicPaymentLectureSch
   @Expose()
   lecture?: PrivateSimpleLecture;
 
-  constructor(lectureSchedule: Partial<PaymentLectureScheduleWithLectureDto>) {
+  constructor(
+    lectureSchedule: Partial<LegacyPaymentLectureScheduleWithLectureDto>,
+  ) {
     super();
     Object.assign(this, lectureSchedule);
   }

--- a/src/payments/dtos/legacy-payment.dto.ts
+++ b/src/payments/dtos/legacy-payment.dto.ts
@@ -6,7 +6,7 @@ import { PaymentStatusDto } from '@src/payments/dtos/payment-status.dto';
 import { PaymentMethodDto } from '@src/payments/dtos/payment-method.dto';
 import { PaymentCouponUsageDto } from '@src/payments/dtos/payment-coupon-usage.dto';
 import { RefundPaymentInfoDto } from '@src/payments/dtos/refund-payment-info.dto';
-import { ReservationDto } from '@src/common/dtos/reservation.dto';
+import { LegacyReservationDto } from '@src/common/dtos/legacy-reservation.dto';
 import { BaseReturnWithSwaggerDto } from '@src/common/dtos/base-return-with-swagger.dto';
 import { PaymentPassUsageDto } from './payment-pass-usage.dto';
 import { UserPassDto } from '@src/common/dtos/user-pass.dto';
@@ -15,7 +15,10 @@ import { CardPaymentInfoDto } from './card-payment-info.dto';
 import { Exclude, Expose } from 'class-transformer';
 
 @Exclude()
-export class PaymentDto extends BaseReturnWithSwaggerDto implements Payment {
+export class LegacyPaymentDto
+  extends BaseReturnWithSwaggerDto
+  implements Payment
+{
   @ApiProperty({
     type: Number,
     description: '결제 Id',
@@ -126,12 +129,12 @@ export class PaymentDto extends BaseReturnWithSwaggerDto implements Payment {
   refundPaymentInfo: RefundPaymentInfoDto;
 
   @ApiProperty({
-    type: ReservationDto,
+    type: LegacyReservationDto,
     description: '예약 정보',
     nullable: true,
   })
   @Expose()
-  reservation: ReservationDto;
+  reservation: LegacyReservationDto;
 
   @ApiProperty({
     type: PaymentPassUsageDto,
@@ -151,7 +154,7 @@ export class PaymentDto extends BaseReturnWithSwaggerDto implements Payment {
 
   secret: string;
 
-  constructor(payment: Partial<PaymentDto>) {
+  constructor(payment: Partial<LegacyPaymentDto>) {
     super();
     Object.assign(this, payment);
 
@@ -163,7 +166,7 @@ export class PaymentDto extends BaseReturnWithSwaggerDto implements Payment {
       ? new PaymentMethodDto(payment.paymentMethod)
       : null;
     this.reservation = payment.reservation
-      ? new ReservationDto(payment.reservation)
+      ? new LegacyReservationDto(payment.reservation)
       : null;
     this.paymentCouponUsage = payment.paymentCouponUsage
       ? new PaymentCouponUsageDto(payment.paymentCouponUsage)

--- a/src/payments/dtos/payment-pass-usage.dto.ts
+++ b/src/payments/dtos/payment-pass-usage.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, OmitType, PickType } from '@nestjs/swagger';
 import { PaymentPassUsage } from '@prisma/client';
 import { LecturePassDto } from '@src/common/dtos/lecture-pass.dto';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, Type } from 'class-transformer';
 
 @Exclude()
 class PaymentPassUsageLecturePassDto extends PickType(LecturePassDto, [
@@ -25,6 +25,7 @@ export class PaymentPassUsageDto implements PaymentPassUsage {
     type: PaymentPassUsageLecturePassDto,
     description: '사용한 패스권 정보',
   })
+  @Type(() => PaymentPassUsageLecturePassDto)
   @Expose()
   lecturePass: PaymentPassUsageLecturePassDto;
 

--- a/src/payments/dtos/pending-payment-info.dto.ts
+++ b/src/payments/dtos/pending-payment-info.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty, OmitType, PickType } from '@nestjs/swagger';
-import { PaymentDto } from './payment.dto';
+import { LegacyPaymentDto } from './legacy-payment.dto';
 import { Exclude, Expose } from 'class-transformer';
 
 @Exclude()
-export class PendingPaymentInfoDto extends PickType(PaymentDto, [
+export class PendingPaymentInfoDto extends PickType(LegacyPaymentDto, [
   'orderId',
   'orderName',
 ]) {

--- a/src/payments/dtos/response/detail-payment.dto.ts
+++ b/src/payments/dtos/response/detail-payment.dto.ts
@@ -1,15 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type, Expose, Exclude } from 'class-transformer';
-import { PaymentPassUsageDto } from '../payment-pass-usage.dto';
-import { BasicPaymentDto } from './basic-payment.dto';
-import { LecturePaymentWithPassUsageDto } from './lecture-payment-with-pass-usage.dto';
-import { ReservationWithLectureDto } from '@src/common/dtos/reservation-with-lecture.dto';
+import { Exclude, Expose, Type } from 'class-transformer';
 import { CardPaymentInfoDto } from '../card-payment-info.dto';
 import { PaymentCouponUsageDto } from '../payment-coupon-usage.dto';
+import { PaymentPassUsageDto } from '../payment-pass-usage.dto';
+import { RefundPaymentInfoDto } from '../refund-payment-info.dto';
 import { VirtualAccountPaymentInfoDto } from '../virtual-account-payment-info.dto';
+import { BasicPaymentDto } from './basic-payment.dto';
+import { ReservationWithLectureImageDto } from '@src/common/dtos/reservation-with-lecture-image.dto';
+import { UserPassDto } from '@src/common/dtos/user-pass.dto';
 
 @Exclude()
-export class PaymentResultDto extends BasicPaymentDto {
+export class DetailPaymentInfo extends BasicPaymentDto {
   @ApiProperty({
     type: PaymentPassUsageDto,
     description: '패스권 사용 내역',
@@ -28,12 +29,12 @@ export class PaymentResultDto extends BasicPaymentDto {
   paymentCouponUsage: PaymentCouponUsageDto;
 
   @ApiProperty({
-    type: ReservationWithLectureDto,
+    type: ReservationWithLectureImageDto,
     description: '예약 정보',
   })
-  @Type(() => ReservationWithLectureDto)
+  @Type(() => ReservationWithLectureImageDto)
   @Expose()
-  reservation: ReservationWithLectureDto;
+  reservation: ReservationWithLectureImageDto;
 
   @ApiProperty({
     type: CardPaymentInfoDto,
@@ -53,10 +54,19 @@ export class PaymentResultDto extends BasicPaymentDto {
   @Expose()
   virtualAccountPaymentInfo: VirtualAccountPaymentInfoDto;
 
-  constructor(
-    lecturePaymentWithPassUsage: Partial<LecturePaymentWithPassUsageDto>,
-  ) {
-    super();
-    Object.assign(this, lecturePaymentWithPassUsage);
-  }
+  @ApiProperty({
+    type: RefundPaymentInfoDto,
+    description: '환불 정보',
+  })
+  @Type(() => RefundPaymentInfoDto)
+  refundPaymentInfo: RefundPaymentInfoDto;
+
+  @ApiProperty({
+    type: UserPassDto,
+    description: '구매한 유저 패스권 정보',
+    nullable: true,
+  })
+  @Type(() => UserPassDto)
+  @Expose()
+  userPass: UserPassDto;
 }

--- a/src/payments/dtos/response/lecture-payment-with-pass-usage.dto.ts
+++ b/src/payments/dtos/response/lecture-payment-with-pass-usage.dto.ts
@@ -1,34 +1,8 @@
-import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose, Type } from 'class-transformer';
 import { BasicPaymentDto } from './basic-payment.dto';
 import { PaymentPassUsageDto } from '../payment-pass-usage.dto';
-import { PaymentMethodDto } from '../payment-method.dto';
-import { ReservationDto } from '@src/common/dtos/reservation.dto';
-import { PaymentProductTypeDto } from '../payment-product-type.dto';
-import { BasicPaymentLectureScheduleDto } from './basic-payment-lecture-schedule.dto';
-import { BasicLectureDto } from '@src/common/dtos/basic-lecture.dto';
-
-@Exclude()
-class LecturePaymentWithPassUsageReservationsDto extends OmitType(
-  ReservationDto,
-  ['regularLectureStatus', 'lectureSchedule'],
-) {
-  @ApiProperty({
-    type: BasicPaymentLectureScheduleDto,
-    description: '강의 일정',
-  })
-  @Type(() => BasicPaymentLectureScheduleDto)
-  @Expose()
-  lectureSchedule: BasicPaymentLectureScheduleDto;
-
-  @ApiProperty({
-    type: BasicLectureDto,
-    description: '강의 정보',
-  })
-  @Type(() => BasicLectureDto)
-  @Expose()
-  lecture: BasicLectureDto;
-}
+import { ReservationWithLectureDto } from '@src/common/dtos/reservation-with-lecture.dto';
 
 @Exclude()
 export class LecturePaymentWithPassUsageDto extends BasicPaymentDto {
@@ -41,12 +15,12 @@ export class LecturePaymentWithPassUsageDto extends BasicPaymentDto {
   paymentPassUsage: PaymentPassUsageDto;
 
   @ApiProperty({
-    type: LecturePaymentWithPassUsageReservationsDto,
+    type: ReservationWithLectureDto,
     description: '예약 정보',
   })
-  @Type(() => LecturePaymentWithPassUsageReservationsDto)
+  @Type(() => ReservationWithLectureDto)
   @Expose()
-  reservation: LecturePaymentWithPassUsageReservationsDto;
+  reservation: ReservationWithLectureDto;
 
   constructor(
     lecturePaymentWithPassUsage: Partial<LecturePaymentWithPassUsageDto>,

--- a/src/payments/dtos/user-payment-history-list.dto.ts
+++ b/src/payments/dtos/user-payment-history-list.dto.ts
@@ -1,29 +1,26 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { PaymentDto } from './payment.dto';
+import { Exclude, Expose, Type } from 'class-transformer';
+import { DetailPaymentInfo } from './response/detail-payment.dto';
 
+@Exclude()
 export class UserPaymentsHistoryWithCountDto {
   @ApiProperty({
     type: Number,
   })
+  @Expose()
   totalItemCount: number;
 
   @ApiProperty({
-    type: [PaymentDto],
+    type: [DetailPaymentInfo],
     description: '결제 내역',
   })
-  userPaymentsHistory: PaymentDto[];
+  @Type(() => DetailPaymentInfo)
+  @Expose()
+  userPaymentsHistory: DetailPaymentInfo[];
 
-  constructor({
-    totalItemCount,
-    userPaymentsHistory,
-  }: Partial<UserPaymentsHistoryWithCountDto>) {
-    this.totalItemCount = totalItemCount;
-    this.userPaymentsHistory = userPaymentsHistory
-      ? userPaymentsHistory.map(
-          (paymentHistory) => new PaymentDto(paymentHistory),
-        )
-      : [];
-
-    Object.assign(this);
+  constructor(
+    userPaymentsHistoryWithCount: Partial<UserPaymentsHistoryWithCountDto>,
+  ) {
+    Object.assign(this, userPaymentsHistoryWithCount);
   }
 }

--- a/src/payments/repository/payments.repository.ts
+++ b/src/payments/repository/payments.repository.ts
@@ -681,37 +681,22 @@ export class PaymentsRepository {
           paymentStatus: true,
           paymentMethod: true,
           paymentCouponUsage: true,
-          transferPaymentInfo: { include: { lecturerBankAccount: true } },
           refundPaymentInfo: {
             include: { refundStatus: true, refundUserBankAccount: true },
           },
           reservation: {
             include: {
-              lectureSchedule: {
-                include: {
-                  lecture: { include: { lectureImage: true } },
-                },
-              },
+              lecture: { include: { lectureImage: true } },
+              lectureSchedule: true,
               regularLectureStatus: {
-                include: { lecture: { include: { lectureImage: true } } },
+                include: { regularLectureSchedule: true },
               },
             },
           },
-
           cardPaymentInfo: { include: { issuer: true, acquirer: true } },
           virtualAccountPaymentInfo: { include: { bank: true } },
-          paymentPassUsage: {
-            include: {
-              lecturePass: true,
-            },
-          },
-          userPass: {
-            include: {
-              lecturePass: {
-                include: { lecturePassTarget: { include: { lecture: true } } },
-              },
-            },
-          },
+          paymentPassUsage: { include: { lecturePass: true } },
+          userPass: { include: { lecturePass: true } },
         },
         orderBy: {
           id: 'desc',
@@ -1033,15 +1018,15 @@ export class PaymentsRepository {
         paymentStatus: true,
         paymentMethod: true,
         paymentCouponUsage: true,
-        transferPaymentInfo: { include: { lecturerBankAccount: true } },
         refundPaymentInfo: {
           include: { refundStatus: true, refundUserBankAccount: true },
         },
         reservation: {
           include: {
-            lectureSchedule: { include: { lecture: true } },
+            lecture: { include: { lectureImage: true } },
+            lectureSchedule: true,
             regularLectureStatus: {
-              include: { lecture: true, regularLectureSchedule: true },
+              include: { regularLectureSchedule: true },
             },
           },
         },

--- a/src/payments/services/payments.service.ts
+++ b/src/payments/services/payments.service.ts
@@ -56,7 +56,7 @@ import axios from 'axios';
 import { CreatePassPaymentDto } from '@src/payments/dtos/create-pass-payment.dto';
 import { CreateLecturePaymentWithPassDto } from '@src/payments/dtos/create-lecture-payment-with-pass.dto';
 import { CreateLecturePaymentWithTransferDto } from '../dtos/create-lecture-payment-with-transfer.dto';
-import { PaymentDto } from '../dtos/payment.dto';
+import { LegacyPaymentDto } from '../dtos/legacy-payment.dto';
 import { CreateLecturePaymentWithDepositDto } from '../dtos/create-lecture-payment-with-deposit';
 import { PendingPaymentInfoDto } from '../dtos/pending-payment-info.dto';
 import { HandleRefundDto } from '../dtos/request/handle-refund.dto';

--- a/src/payments/services/user-payments.service.ts
+++ b/src/payments/services/user-payments.service.ts
@@ -13,7 +13,9 @@ import { UserBankAccountDto } from '@src/payments/dtos/user-bank-account.dto';
 import { IPaginationParams } from '@src/common/interface/common-interface';
 import { PaymentHistoryTypes } from '../constants/enum';
 import { UserPaymentsHistoryWithCountDto } from '../dtos/user-payment-history-list.dto';
-import { PaymentDto } from '../dtos/payment.dto';
+import { LegacyPaymentDto } from '../dtos/legacy-payment.dto';
+import { DetailPaymentInfo } from '../dtos/response/detail-payment.dto';
+import { plainToInstance } from 'class-transformer';
 
 @Injectable()
 export class UserPaymentsService implements OnModuleInit {
@@ -127,7 +129,10 @@ export class UserPaymentsService implements OnModuleInit {
     return { cursor, skip, take: updatedTake };
   }
 
-  async getUserReceipt(userId: number, orderId: string): Promise<PaymentDto> {
+  async getUserReceipt(
+    userId: number,
+    orderId: string,
+  ): Promise<DetailPaymentInfo> {
     const receipt = await this.paymentsRepository.getUserPaymentInfo(
       userId,
       orderId,
@@ -139,6 +144,6 @@ export class UserPaymentsService implements OnModuleInit {
       );
     }
 
-    return new PaymentDto(receipt);
+    return plainToInstance(DetailPaymentInfo, receipt);
   }
 }

--- a/src/payments/swagger-decorators/create-lecture-payment-info-with-deposit-decorater.ts
+++ b/src/payments/swagger-decorators/create-lecture-payment-info-with-deposit-decorater.ts
@@ -9,7 +9,7 @@ import {
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import { SwaggerApiResponse } from '@src/common/swagger/swagger-response';
 import { DetailResponseDto } from '@src/common/swagger/dtos/detail-response-dto';
-import { PaymentDto } from '../dtos/payment.dto';
+import { LegacyPaymentDto } from '../dtos/legacy-payment.dto';
 
 export function ApiCreateLecturePaymentWithDeposit() {
   return applyDecorators(
@@ -21,7 +21,7 @@ export function ApiCreateLecturePaymentWithDeposit() {
     DetailResponseDto.swaggerBuilder(
       HttpStatus.CREATED,
       'depositPaymentResult',
-      PaymentDto,
+      LegacyPaymentDto,
     ),
     ApiBadRequestResponse(
       SwaggerApiResponse.exception([

--- a/src/payments/swagger-decorators/create-lecture-payment-info-with-transfer-decorater.ts
+++ b/src/payments/swagger-decorators/create-lecture-payment-info-with-transfer-decorater.ts
@@ -9,7 +9,7 @@ import {
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import { SwaggerApiResponse } from '@src/common/swagger/swagger-response';
 import { DetailResponseDto } from '@src/common/swagger/dtos/detail-response-dto';
-import { PaymentDto } from '../dtos/payment.dto';
+import { LegacyPaymentDto } from '../dtos/legacy-payment.dto';
 
 export function ApiCreateLecturePaymentWithTransfer() {
   return applyDecorators(
@@ -21,7 +21,7 @@ export function ApiCreateLecturePaymentWithTransfer() {
     DetailResponseDto.swaggerBuilder(
       HttpStatus.CREATED,
       'transferPaymentResult',
-      PaymentDto,
+      LegacyPaymentDto,
     ),
     ApiBadRequestResponse(
       SwaggerApiResponse.exception([

--- a/src/payments/swagger-decorators/get-user-payments-history-decorator.ts
+++ b/src/payments/swagger-decorators/get-user-payments-history-decorator.ts
@@ -6,7 +6,7 @@ import {
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import { SwaggerApiResponse } from '@src/common/swagger/swagger-response';
 import { PaginationResponseDto } from '@src/common/swagger/dtos/pagination-response.dto';
-import { PaymentDto } from '../dtos/payment.dto';
+import { DetailPaymentInfo } from '../dtos/response/detail-payment.dto';
 
 export function ApiGetUserPaymentsHistory() {
   return applyDecorators(
@@ -18,7 +18,7 @@ export function ApiGetUserPaymentsHistory() {
     PaginationResponseDto.swaggerBuilder(
       HttpStatus.OK,
       'userPaymentsHistory',
-      PaymentDto,
+      DetailPaymentInfo,
     ),
     ApiUnauthorizedResponse(
       SwaggerApiResponse.exception([

--- a/src/payments/swagger-decorators/get-user-receipt-decorator.ts
+++ b/src/payments/swagger-decorators/get-user-receipt-decorator.ts
@@ -1,15 +1,13 @@
 import {
-  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiNotFoundResponse,
-  ApiOkResponse,
   ApiOperation,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import { SwaggerApiResponse } from '@src/common/swagger/swagger-response';
 import { DetailResponseDto } from '@src/common/swagger/dtos/detail-response-dto';
-import { PaymentDto } from '../dtos/payment.dto';
+import { DetailPaymentInfo } from '../dtos/response/detail-payment.dto';
 
 export function ApiGetUserReceipt() {
   return applyDecorators(
@@ -18,7 +16,11 @@ export function ApiGetUserReceipt() {
       description: 'orderId를 통한 결제 정보 상세 조회(유저)',
     }),
     ApiBearerAuth(),
-    DetailResponseDto.swaggerBuilder(HttpStatus.OK, 'receipt', PaymentDto),
+    DetailResponseDto.swaggerBuilder(
+      HttpStatus.OK,
+      'receipt',
+      DetailPaymentInfo,
+    ),
     ApiNotFoundResponse(
       SwaggerApiResponse.exception([
         {


### PR DESCRIPTION
* 사용하지 않는 Dto 제거
* 스케쥴 구조 변경에 따른 새로운 Reservation 추가 및 변경이 적용되지 않은 reservationDto -> legacy로 네이밍
* 스케쥴 변경으로 인한 lectureScheduleDto, regularScheduleDto -> legacy로 변경
* 모든 결제 정보가 포함된 PaymentDto(legacy reservation 포함) -> legacy로 변경
* DetailPaymentInfoDto 생성 및 일부 적용